### PR TITLE
Remove probably useless line from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,3 @@ Thumbs.db
 .idea
 .gradle
 build/
-
-*ASUS_PC_01*
-


### PR DESCRIPTION
This seems to have already been removed in a PR on the deprecated repository, but that PR wasn't actually merged. (https://github.com/ftctechnh/ftc_app/pull/175)